### PR TITLE
Make CellInput TextInput's ref accessible

### DIFF
--- a/components/CellInput.js
+++ b/components/CellInput.js
@@ -25,7 +25,7 @@ class CellInput extends React.Component {
     rows: PropTypes.number,
     minRows: PropTypes.number,
     autoResize: PropTypes.bool,
-    textRef: PropTypes.func
+    textInputRef: PropTypes.func
   }
 
   constructor(props) {
@@ -72,8 +72,8 @@ class CellInput extends React.Component {
     return (
       <TextInput
         ref={(component) => {
-          if (this.props.textRef) {
-              this.props.textRef(component);
+          if (this.props.textInputRef) {
+              this.props.textInputRef(component);
           }
           this._textInput = component
         }}

--- a/components/CellInput.js
+++ b/components/CellInput.js
@@ -24,7 +24,8 @@ class CellInput extends React.Component {
     ...TextInput.propTypes,
     rows: PropTypes.number,
     minRows: PropTypes.number,
-    autoResize: PropTypes.bool
+    autoResize: PropTypes.bool,
+    textRef: PropTypes.func
   }
 
   constructor(props) {
@@ -70,7 +71,12 @@ class CellInput extends React.Component {
   renderTextInput() {
     return (
       <TextInput
-        ref={component => this._textInput = component}
+        ref={(component) => {
+          if (this.props.textRef) {
+              this.props.textRef(component);
+          }
+          this._textInput = component
+        }}
         clearButtonMode="while-editing"
         selectionColor={theme.color.info}
         placeholderTextColor={this.props.placeholderTextColor || theme.color.muted}


### PR DESCRIPTION
Added a new prop to make `CellInput` TextInput's `ref` accessible. Example usage:

```
<CellInput
    {/*...*/}
    textInputRef={(r) => {this._inputRef = r}}
/>
```

The reason for it is e.g. when using Keyboard aware ScrollView mechanisms and need to keep track of TextInput's focus state.