### PR TITLE
fix 'isIphoneX' duplicate error

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -25,17 +25,6 @@ const colors = {
   lightGrey: '#e9e9e9'
 };
 
-// https://github.com/ptelad/react-native-iphone-x-helper/blob/master/index.js
-function isIphoneX() {
-    let dimen = Dimensions.get('window');
-    return (
-        Platform.OS === 'ios' &&
-        !Platform.isPad &&
-        !Platform.isTVOS &&
-        (dimen.height === 812 || dimen.width === 812)
-    );
-}
-
 const value = (ios = null, android = null) => {
   return Platform.select({
     ios,
@@ -43,7 +32,16 @@ const value = (ios = null, android = null) => {
   });
 };
 
-const isIphoneX = isIphoneX();
+// https://github.com/ptelad/react-native-iphone-x-helper/blob/master/index.js
+const isIphoneX = (function() {
+  let dimen = Dimensions.get('window');
+  return (
+    Platform.OS === 'ios' &&
+    !Platform.isPad &&
+    !Platform.isTVOS &&
+    (dimen.height === 812 || dimen.width === 812)
+  );
+})();
 const borderWidth = StyleSheet.hairlineWidth;
 const radius = value(5, 2);
 const padding = value(10, 16);


### PR DESCRIPTION
I always get this error:

```
error: bundling failed: SyntaxError: /node_modules/react-native-cell-components/lib/theme.js: Identifier 'isIphoneX' has already been declared (46:6)

  44 | };
  45 | 
> 46 | const isIphoneX = isIphoneX();
     |       ^
  47 | const borderWidth = StyleSheet.hairlineWidth;
  48 | const radius = value(5, 2);
  49 | const padding = value(10, 16);
```

This PR will fix it.